### PR TITLE
Fix Mautic version in composer.json + match php requirement

### DIFF
--- a/README.md
+++ b/README.md
@@ -115,14 +115,14 @@ section of composer.json:
 
 ### How do I specify a PHP version ?
 
-This project supports PHP 7.0 as minimum version, however it's possible that a `composer update` will upgrade some package that will then require PHP 7+.
+This project supports PHP 7.2.21 as minimum version, however it's possible that a `composer update` will upgrade some package that will then require PHP 7+.
 
 To prevent this you can add this code to specify the PHP version you want to use in the `config` section of `composer.json`:
 ```json
 "config": {
     "sort-packages": true,
     "platform": {
-        "php": "7.0.33"
+        "php": "7.2.21"
     }
 },
 ```

--- a/composer.json
+++ b/composer.json
@@ -1,6 +1,6 @@
 {
   "name": "nickveenhof/mautic-project",
-  "description": "Project template for Mautic 2 projects with composer",
+  "description": "Project template for Mautic 3 projects with composer",
   "type": "project",
   "license": "GPL-2.0-or-later",
   "authors": [
@@ -10,7 +10,7 @@
     }
   ],
   "require": {
-    "php": ">=7.0.8",
+    "php": ">=7.2.21 <7.4",
     "mautic/core": "3.x-dev",
     "nickveenhof/mautic-core-composer-scaffold": "^0.1",
     "nickveenhof/mautic-finder": "^0.1",


### PR DESCRIPTION
Just fixed the name since the v3 branch is saying V2.

And I also change the php requirements to match the ones listed on mautic core:
https://packagist.org/packages/mautic/core