### PR TITLE
Fix wrong root folder in README since the name has been changed

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,13 +35,13 @@ all files not excluded by the .gitignore file.
 
 When installing the given `composer.json` some tasks are taken care of:
 
-* Mautic will be installed in the `web`-directory.
+* Mautic will be installed in the `public`-directory.
 * Autoloader is implemented to use the generated composer autoloader in `vendor/autoload.php`,
-  instead of the one provided by Mautic (`web/vendor/autoload.php`).
-* Modules (packages of type `mautic-plugin`) will be placed in `web/plugins/`
-* Theme (packages of type `mautic-theme`) will be placed in `web/themes/`
+  instead of the one provided by Mautic (`public/vendor/autoload.php`).
+* Modules (packages of type `mautic-plugin`) will be placed in `public/plugins/`
+* Theme (packages of type `mautic-theme`) will be placed in `public/themes/`
 * Creates default writable versions of `settings.php` and `services.yml`.
-* Creates `web/media`-directory.
+* Creates `public/media`-directory.
 * Creates environment variables based on your .env file. See [.env.example](.env.example).
 
 ## Updating Mautic Core
@@ -59,7 +59,7 @@ Follow the steps below to update your core files.
 2. Run `git diff` to determine if any of the scaffolding files have changed.
    Review the files for any changes and restore any customizations to
   `.htaccess` or `robots.txt`.
-1. Commit everything all together in a single commit, so `web` will remain in
+1. Commit everything all together in a single commit, so `public` will remain in
    sync with the `core` when checking out branches or running `git bisect`.
 1. In the event that there are non-trivial conflicts in step 2, you may wish
    to perform these steps on a branch, and use `git merge` to combine the
@@ -78,7 +78,7 @@ workrounds if a project decides to do it anyway](https://getcomposer.org/doc/faq
 ### Should I commit the scaffolding files?
 
 The [Mautic Composer Scaffold](https://github.com/nickveenhof/mautic-core-composer-scaffold) plugin can download the scaffold files (like
-index.php, update.php, …) to the web/ directory of your project. If you have not customized those files you could choose
+index.php, update.php, …) to the public/ directory of your project. If you have not customized those files you could choose
 to not check them into your version control system (e.g. git). If that is the case for your project it might be
 convenient to automatically run the mautic-scaffold plugin after every install or update of your project. You can
 achieve that by registering `@composer mautic:scaffold` as post-install and post-update command in your composer.json:


### PR DESCRIPTION
This commit changed the name of the root folder from "web" to "public". The README has not been changed.

https://github.com/nickveenhof/mautic-project/commit/aa3d997c8aa5ce9b88e7dfe5009e8dad8ee1eff7